### PR TITLE
Fix for App Breaking "Alphabet" is read-only error

### DIFF
--- a/AlphabetPicker.js
+++ b/AlphabetPicker.js
@@ -13,7 +13,7 @@ class LetterPicker extends Component {
     }
 }
 
-const Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split('');
+let Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split('');
 export default class AlphabetPicker extends Component {
     constructor(props, context) {
         super(props, context);


### PR DESCRIPTION
Current implementation breaks application when using AtoZList Component. By setting the Alphabet variable to a mutable variable rather than a constant (on line 16 of AlphabetPicker.js) resolves this error. If this pull request gets accepted please publish the fix to NPM as well, so that this becomes a working component again for applications that rely on it.